### PR TITLE
Develop

### DIFF
--- a/include/DGTypes.h
+++ b/include/DGTypes.h
@@ -16,8 +16,10 @@
 #define msgUPDATEREQUEST "Request Update"
 #define msgSTATUS "Status"
 
+#define HASH_LEN 512
 #define MAX_PASSWD_LEN 128
 #define MAX_THREADS 2048
+
 
 typedef enum {
     MD4HashType,
@@ -36,7 +38,7 @@ typedef enum {
 } DGStatus;
 
 struct hashData_t {
-    unsigned char hash[512], salt[64];
+    unsigned char hash[HASH_LEN], salt[64];
     char passwd[MAX_PASSWD_LEN], saltString[64];
     int rounds;
     DGHashType hashType = UnknownHashType;

--- a/include/OCMD4.h
+++ b/include/OCMD4.h
@@ -7,7 +7,15 @@
 #include <string.h>
 #include <sys/types.h>
 #include <stdio.h>
-#include <openssl/md4.h>
+
+// El Capitan drops support for openssl
+#include <Availability.h>
+#ifdef MAC_OS_X_VERSION_10_11
+        #include <apr-1/apr_md4.h>
+#else
+        #include <openssl/md4.h>
+#endif
+
 #include <CommonCrypto/CommonDigest.h>
 #import <Foundation/Foundation.h>
 

--- a/include/OCMD4.h
+++ b/include/OCMD4.h
@@ -8,14 +8,6 @@
 #include <sys/types.h>
 #include <stdio.h>
 
-// El Capitan drops support for openssl
-#include <Availability.h>
-#ifdef MAC_OS_X_VERSION_10_11
-        #include <apr-1/apr_md4.h>
-#else
-        #include <openssl/md4.h>
-#endif
-
 #include <CommonCrypto/CommonDigest.h>
 #import <Foundation/Foundation.h>
 

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ JOYMESG := "\nMake succeeded...\nCreated: $(TARGET)"
 SRCEXT := cpp
 SOURCES := $(shell find $(SRCDIR) -type f -name *.$(SRCEXT))
 OBJECTS := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.$(SRCEXT)=.o))
-CFLAGS := -std=c++11 -stdlib=libc++ -mmacosx-version-min=10.7 -fobjc-arc -fobjc-nonfragile-abi -arch x86_64 -ObjC++ -O3 
+CFLAGS := -std=c++11 -stdlib=libc++ -fobjc-arc -fobjc-nonfragile-abi -arch x86_64 -ObjC++ -O3 
 LIB := -L $(LIBDIR) -framework Foundation
 INC := -I include
 

--- a/src/DGAttack.cpp
+++ b/src/DGAttack.cpp
@@ -296,8 +296,7 @@ int crackWordlist(const char * wordlist, int threadNum){
 }
 
 int tryPassword(hashData_t *userHashData, const char *passwd){
-    // static __thread hashData_t guessHashData;
-    static __thread unsigned char hash[512];  
+    static __thread unsigned char hash[HASH_LEN];  
 
     if (userHashData->hashType == PBKDF2HashType) {
         CCKeyDerivationPBKDF(kCCPBKDF2, passwd, strlen(passwd), userHashData->salt, 32, kCCPRFHmacAlgSHA512, userHashData->rounds, hash, 128);

--- a/src/DGAttack.cpp
+++ b/src/DGAttack.cpp
@@ -296,24 +296,25 @@ int crackWordlist(const char * wordlist, int threadNum){
 }
 
 int tryPassword(hashData_t *userHashData, const char *passwd){
-    static __thread hashData_t guessHashData;
-    
+    // static __thread hashData_t guessHashData;
+    static __thread unsigned char hash[512];  
+
     if (userHashData->hashType == PBKDF2HashType) {
-        CCKeyDerivationPBKDF(kCCPBKDF2, passwd, strlen(passwd), userHashData->salt, 32, kCCPRFHmacAlgSHA512, userHashData->rounds, guessHashData.hash, 128);
+        CCKeyDerivationPBKDF(kCCPBKDF2, passwd, strlen(passwd), userHashData->salt, 32, kCCPRFHmacAlgSHA512, userHashData->rounds, hash, 128);
         
-        if (memcmp(userHashData->hash, guessHashData.hash, 128) == 0){
+        if (memcmp(userHashData->hash, hash, 128) == 0){
             return 0;
         }
     } else if (userHashData->hashType == SHA512HashType) {
-        SHA512Hash(guessHashData.hash, passwd, userHashData->salt);
+        SHA512Hash(hash, passwd, userHashData->salt);
         
-        if (memcmp(&userHashData->hash[4] ,guessHashData.hash ,64) == 0) {
+        if (memcmp(&userHashData->hash[4] ,hash ,64) == 0) {
             return 0;
         }
     } else if (userHashData->hashType == MD4HashType){
-        CalculateSMBNTHash(passwd, guessHashData.hash);
+        CalculateSMBNTHash(passwd, hash);
         
-        if (memcmp(userHashData->hash ,guessHashData.hash ,16) == 0) {
+        if (memcmp(userHashData->hash ,hash ,16) == 0) {
             return 0;
         }
     }

--- a/src/DGCracker.cpp
+++ b/src/DGCracker.cpp
@@ -225,24 +225,25 @@ int theIncrementalAttack(crack_t *theParams, hashData_t *theHashData, int thread
 
 
 int attemptPassword(hashData_t *userHashData, const char *passwd){
-    static __thread hashData_t guessHashData;
-    
+    // static __thread hashData_t guessHashData;
+    static __thread unsigned char hash[512];
+
     if (userHashData->hashType == PBKDF2HashType) {
-        CCKeyDerivationPBKDF(kCCPBKDF2, passwd, strlen(passwd), userHashData->salt, 32, kCCPRFHmacAlgSHA512, userHashData->rounds, guessHashData.hash, 128);
+        CCKeyDerivationPBKDF(kCCPBKDF2, passwd, strlen(passwd), userHashData->salt, 32, kCCPRFHmacAlgSHA512, userHashData->rounds, hash, 128);
         
-        if (memcmp(userHashData->hash, guessHashData.hash, 128) == 0){
+        if (memcmp(userHashData->hash, hash, 128) == 0){
             return 0;
         }
     } else if (userHashData->hashType == SHA512HashType) {
-        SHA512Hash(guessHashData.hash, passwd, userHashData->salt);
+        SHA512Hash(hash, passwd, userHashData->salt);
         
-        if (memcmp(&userHashData->hash[4] ,guessHashData.hash ,64) == 0) {
+        if (memcmp(&userHashData->hash[4] ,hash ,64) == 0) {
             return 0;
         }
     } else if (userHashData->hashType == MD4HashType){
-        CalculateSMBNTHash(passwd, guessHashData.hash);
+        CalculateSMBNTHash(passwd, hash);
         
-        if (memcmp(userHashData->hash ,guessHashData.hash ,16) == 0) {
+        if (memcmp(userHashData->hash ,hash ,16) == 0) {
             return 0;
         }
     }

--- a/src/DGCracker.cpp
+++ b/src/DGCracker.cpp
@@ -225,8 +225,7 @@ int theIncrementalAttack(crack_t *theParams, hashData_t *theHashData, int thread
 
 
 int attemptPassword(hashData_t *userHashData, const char *passwd){
-    // static __thread hashData_t guessHashData;
-    static __thread unsigned char hash[512];
+    static __thread unsigned char hash[HASH_LEN];
 
     if (userHashData->hashType == PBKDF2HashType) {
         CCKeyDerivationPBKDF(kCCPBKDF2, passwd, strlen(passwd), userHashData->salt, 32, kCCPRFHmacAlgSHA512, userHashData->rounds, hash, 128);

--- a/src/OCHashing.cpp
+++ b/src/OCHashing.cpp
@@ -23,7 +23,7 @@ int getPBKDF2Data(NSString *plistPath, uint8_t theKey[], uint8_t theSalt[], int 
     
     NSDictionary *plist = [[NSDictionary alloc] initWithContentsOfFile:plistPath];
     NSData *hashData = [[NSData alloc] initWithData:[[plist objectForKey:@"ShadowHashData"] objectAtIndex:0]];
-    NSDictionary *shadowHashData = [NSPropertyListSerialization propertyListFromData:hashData mutabilityOption:NSPropertyListMutableContainersAndLeaves format:NULL errorDescription:NULL];
+    NSDictionary *shadowHashData = [NSPropertyListSerialization propertyListWithData:hashData options:NSPropertyListMutableContainersAndLeaves format:NULL error:NULL];
     NSDictionary *pbkdf2 = [[NSDictionary alloc] initWithDictionary:[shadowHashData objectForKey:@"SALTED-SHA512-PBKDF2"]];
     
     memcpy(theKey, [[pbkdf2 objectForKey:@"entropy"] bytes], [[pbkdf2 objectForKey:@"entropy"] length]);

--- a/src/OCShadowHashData.cpp
+++ b/src/OCShadowHashData.cpp
@@ -27,7 +27,9 @@
     
     NSDictionary *thePlistDictionary = [[NSDictionary alloc] initWithContentsOfFile:thePlist];
     NSData *hashData = [[NSData alloc] initWithData:[[thePlistDictionary objectForKey:@"ShadowHashData"] objectAtIndex:0]];
-    shadowHashData = [NSPropertyListSerialization propertyListFromData:hashData mutabilityOption:NSPropertyListMutableContainersAndLeaves format:NULL errorDescription:NULL];
+    // shadowHashData = [NSPropertyListSerialization propertyListFromData:hashData mutabilityOption:NSPropertyListMutableContainersAndLeaves format:NULL errorDescription:NULL];
+    
+    shadowHashData = [NSPropertyListSerialization propertyListWithData:hashData options:NSPropertyListMutableContainersAndLeaves format:NULL error:NULL];
     
 }
 


### PR DESCRIPTION
Cleaned out some unused 'openssl' includes as well as some deprecated plist methods.  Also fixed the thread local storage compile error for Xcode 6.3 and 7. Dave now compiles normally again.
